### PR TITLE
Add containerSecurityContext

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
       - run: helm dependency update tests/chart
       - run: helm lint tests/chart
       - run: helm template --namespace=default test tests/chart > tests/actual.yaml
-      - run: diff --ignore-trailing-space tests/actual.yaml tests/expected.yaml
+      - run: diff -Naur --ignore-trailing-space tests/expected.yaml tests/actual.yaml
 
       - name: Publish
         run: c2cciutils-publish

--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ common.podConfig" ( dict
   )
 )
 ```
+
+# Security context
+
+To fill the `securityContext` we use `securityContext` in the pod and `containerSecurityContext` in the container.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -113,7 +113,7 @@ tolerations:
 {{- end }}
 
 {{- define "common.containerConfig" -}}
-securityContext: {{- toYaml .root.Values.securityContext | nindent 2 }}
+securityContext: {{- toYaml .root.Values.containerSecurityContext | nindent 2 }}
 {{- if .container.image.sha }}
 image: "{{ .container.image.repository }}@sha256:{{ .container.image.sha }}"
 {{- else }}

--- a/tests/chart/values.yaml
+++ b/tests/chart/values.yaml
@@ -61,19 +61,37 @@ sub:
       cpu: 10m
     limits:
       memory: 1Gi
+      cpu: 1
+
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 33 # www-data
+    readOnlyRootFilesystem: true
+
+containerSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 34
+  readOnlyRootFilesystem: true
 
 serviceAccount:
   create: false
   name: default
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 35
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 33 # www-data
-  readOnlyRootFilesystem: true
+  runAsUser: 36
 
-resources: {}
+resources:
+  requests:
+    memory: 200Mi
+    cpu: 20m
+  limits:
+    memory: 2Gi
+    cpu: 2
 
 nodeSelector: {}
 

--- a/tests/expected.yaml
+++ b/tests/expected.yaml
@@ -30,9 +30,8 @@ spec:
 
       serviceAccountName: default
       securityContext:
-        readOnlyRootFilesystem: true
         runAsNonRoot: true
-        runAsUser: 33
+        runAsUser: 36
       affinity:
         {}
       containers:
@@ -40,12 +39,17 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 33
+            runAsUser: 34
           image: "camptocamp/main:latest"
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
-            {}
+            limits:
+              cpu: 2
+              memory: 2Gi
+            requests:
+              cpu: 20m
+              memory: 200Mi
 ---
 # Source: testlib/templates/sub-deployment.yaml
 apiVersion: apps/v1
@@ -78,9 +82,8 @@ spec:
 
       serviceAccountName: default
       securityContext:
-        readOnlyRootFilesystem: true
         runAsNonRoot: true
-        runAsUser: 33
+        runAsUser: 36
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -104,7 +107,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 33
+            runAsUser: 34
           image: "camptocamp/sub@sha256:1234"
           imagePullPolicy: IfNotPresent
           env:
@@ -130,6 +133,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
             limits:
+              cpu: 1
               memory: 1Gi
             requests:
               cpu: 10m
@@ -137,6 +141,7 @@ spec:
 ---
 # Source: testlib/templates/test.yaml
 Chart:
+  IsRoot: true
   apiVersion: v2
   appVersion: "1.0"
   dependencies:
@@ -156,6 +161,10 @@ Values:
     global: {}
   configMapNameOverride:
     cm2: overitten
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 34
   env: {}
   fullnameOverride: ""
   image:
@@ -166,17 +175,28 @@ Values:
   imagePullSecrets: []
   nameOverride: ""
   nodeSelector: {}
-  podSecurityContext: {}
-  replicaCount: 1
-  resources: {}
-  securityContext:
-    readOnlyRootFilesystem: true
+  podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 33
+    runAsUser: 35
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 20m
+      memory: 200Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 36
   serviceAccount:
     create: false
     name: default
   sub:
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 33
     env:
       comfigmap:
         key: data
@@ -201,6 +221,7 @@ Values:
       tag: latest
     resources:
       limits:
+        cpu: 1
         memory: 1Gi
       requests:
         cpu: 10m


### PR DESCRIPTION
To be able to define different `securityContext` in the pod and in the container when we use the same config

The issue is that the `readOnlyRootFilesystem` can only be in the container