### PR TITLE
Be able to get more values from global

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
             |tests/chart/.*$
           )
         args:
-          - release-long-name-release-long-name-release
+          - release-name
           - tests/chart
           - tests/expected.yaml
       - id: helm-template-gen

--- a/README.md
+++ b/README.md
@@ -44,8 +44,19 @@ Parameters:
 - `serviceName`: the service name default value (optional).
 
 Used values:
+[`serviceName`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/serviceName).
 
-- [`serviceName`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/serviceName) from the service object.
+### `common.nameNoTrunc`
+
+Expand the name of the chart.
+
+Parameters:
+
+- `root`: the root object, should be `$`.
+- `service`: the service object.
+
+Used values:
+[`nameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameOverride).
 
 ### `common.name`
 
@@ -57,14 +68,16 @@ Parameters:
 - `service`: the service object.
 
 Used values:
+[`nameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameOverride),
+[`nameTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameTrunc).
 
-- [`nameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameOverride) from the service object.
+Used functions:
 
-### `common.fullname`
+- `common.nameNoTrunc`
 
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+### `common.releaseNameNoTrunc`
+
+Expand the name of the release.
 
 Parameters:
 
@@ -72,14 +85,52 @@ Parameters:
 - `service`: the service object.
 
 Used values:
+[`releaseNameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/releaseNameOverride).
 
-- [`fullnameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/fullnameOverride) from the service object.
-- [`nameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameOverride) from the service object.
-- [`releaseTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/releaseTrunc) from the service object.
-- [`prefixTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/prefixTrunc) from the service object.
+### `common.releaseName`
+
+Expand the name of the release.
+
+Parameters:
+
+- `root`: the root object, should be `$`.
+- `service`: the service object.
+
+Used values:
+[`releaseNameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/releaseNameOverride),
+[`releaseTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/releaseTrunc).
 
 Used functions:
 
+- `common.releaseNameNoTrunc`
+
+### `common.fullname`
+
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+
+The full name is the concatenation of a prefix, and a service name `<prefix>-<service-name>`.
+
+Where the prefix is the release name or the chart name (also just named name) of the chart `<release-name>-<chart-name>`.
+
+Parameters:
+
+- `root`: the root object, should be `$`.
+- `service`: the service object.
+
+Used values:
+[`releaseNameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/releaseNameOverride),
+[`nameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameOverride),
+[`fullnameOverride`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/fullnameOverride),
+[`releaseTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/releaseTrunc),
+[`nameTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/nameTrunc),
+[`prefixTrunc`](https://github.com/camptocamp/helm-common/blob/master/values.md#definitions/prefixTrunc).
+
+Used functions:
+
+- `common.releaseName`
+- `common.name`
 - `common.servicenamePostfix`
 
 ### `common.chart`

--- a/tests/chart/Chart.yaml
+++ b/tests/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: '1.0'
 description: Test
-name: chart-long-name-chart-long-name-chart-long-name-chart
+name: chart-name
 version: 0.1.0
 dependencies:
   - name: common

--- a/tests/chart/templates/configmap.yaml
+++ b/tests/chart/templates/configmap.yaml
@@ -1,16 +1,18 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "common.fullname" ( dict "root" . "service" .Values ) }}-env
+  name: {{ include "common.fullname" ( dict "root" . "service" .Values "serviceName" "env" ) }}
   labels: {{ include "common.labels" ( dict "root" . "service" .Values ) | nindent 4 }}
 data:
   servicenamePostfix: _{{ include "common.servicenamePostfix" ( dict "service" .Values ) }}
-  servicenamePostfix_servicename: {{ include "common.servicenamePostfix" ( dict "service" .Values "serviceName" "argument-long-servcie-name-argument-long-servcie-name-argument" )}}
+  servicenamePostfix_servicename: {{ include "common.servicenamePostfix" ( dict "service" .Values "serviceName" "argument-service-name" )}}
   name: {{ include "common.name" ( dict "root" . "service" .Values ) }}
   name_nameOverride: {{ include "common.name" ( dict "root" . "service" .Values.nameOverrideObject ) }}
+  name_valueOverride: {{ include "common.name" ( dict "root" .Values.rootNameOverrideObject "service" .Values ) }}
+  name_valueOverride_nameOverride: {{ include "common.name" ( dict "root" .Values.rootNameOverrideObject "service" .Values.nameOverrideObject ) }}
   fullname: {{ include "common.fullname" ( dict "root" . "service" .Values ) }}
   fullname_fullnameOverride: {{ include "common.fullname" ( dict "root" . "service" .Values.fullnameOverrideObject ) }}
-  fullname_fullnameOverride_servicename: {{ include "common.fullname" ( dict "root" . "service" .Values.fullnameOverrideObject "serviceName" "argument-long-servcie-name-argument-long-servcie-name-argument" ) }}
+  fullname_fullnameOverride_servicename: {{ include "common.fullname" ( dict "root" . "service" .Values.fullnameOverrideObject "serviceName" "argument-service-name" ) }}
   fullname_nameOverride: {{ include "common.fullname" ( dict "root" . "service" .Values.nameOverrideObject ) }}
-  fullname_nameOverride_servicename: {{ include "common.fullname" ( dict "root" . "service" .Values.nameOverrideObject "serviceName" "argument-long-servcie-name-argument-long-servcie-name-argument" ) }}
+  fullname_nameOverride_servicename: {{ include "common.fullname" ( dict "root" . "service" .Values.nameOverrideObject "serviceName" "argument-service-name" ) }}
   chart: {{ include "common.chart" . }}

--- a/tests/chart/values.yaml
+++ b/tests/chart/values.yaml
@@ -5,12 +5,20 @@ nameOverride: ''
 fullnameOverride: ''
 
 nameOverrideObject:
-  nameOverride: 'value-long-name-override-value-long-name-override-value'
+  nameOverride: name-override
   fullnameOverride: ''
+
+rootNameOverrideObject:
+  Chart:
+    Name: chart-name
+  Release:
+    Name: release-name
+  Values:
+    nameOverride: values-override
 
 fullnameOverrideObject:
   nameOverride: ''
-  fullnameOverride: 'value-long-full-name-override-value-long-full-name-override-value'
+  fullnameOverride: full-name-override
 
 annotations:
   name: main

--- a/tests/expected.yaml
+++ b/tests/expected.yaml
@@ -1,24 +1,26 @@
 ---
-# Source: chart-long-name-chart-long-name-chart-long-name-chart/templates/configmap.yaml
+# Source: chart-name/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: release-long-name-re-chart-long-name-cha-env
+  name: release-name-chart-name-env
   labels:
-    helm.sh/chart: chart-long-name-chart-long-name-chart-long-name-chart
+    helm.sh/chart: chart-name
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: chart-long-name-chart-long-name-chart-long-name-chart
-    app.kubernetes.io/instance: release-long-name-release-long-name-release
+    app.kubernetes.io/name: chart-name
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: main
 data:
   servicenamePostfix: _
-  servicenamePostfix_servicename: argument-long-servcie-name-argument-long-servcie-name-argument
-  name: chart-long-name-chart-long-name-chart-long-name-chart
-  name_nameOverride: value-long-name-override-value-long-name-override-value
-  fullname: release-long-name-re-chart-long-name-cha
-  fullname_fullnameOverride: value-long-full-name-override
-  fullname_fullnameOverride_servicename: value-long-full-name-override-argument-long-servcie-name-argume
-  fullname_nameOverride: release-long-name-re-value-long-name-ove
-  fullname_nameOverride_servicename: release-long-name-re-value-long-name-ove-argument-long-servcie
-  chart: chart-long-name-chart-long-name-chart-long-name-chart
+  servicenamePostfix_servicename: argument-service-name
+  name: chart-name
+  name_nameOverride: name-override
+  name_valueOverride: values-override
+  name_valueOverride_nameOverride: name-override
+  fullname: release-name-chart-name
+  fullname_fullnameOverride: full-name-override
+  fullname_fullnameOverride_servicename: full-name-override-argument-service-name
+  fullname_nameOverride: release-name-name-override
+  fullname_nameOverride_servicename: release-name-name-override-argument-service-name
+  chart: chart-name

--- a/tests/expected_long_service_name.yaml
+++ b/tests/expected_long_service_name.yaml
@@ -1,24 +1,26 @@
 ---
-# Source: chart-long-name-chart-long-name-chart-long-name-chart/templates/configmap.yaml
+# Source: chart-name/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: release-long-name-re-chart-long-name-cha-value-long-service-nam-env
+  name: release-long-name-re-chart-name-value-long-service-name-value-l
   labels:
-    helm.sh/chart: chart-long-name-chart-long-name-chart-long-name-chart
+    helm.sh/chart: chart-name
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: chart-long-name-chart-long-name-chart-long-name-chart
+    app.kubernetes.io/name: chart-name
     app.kubernetes.io/instance: release-long-name-release-long-name-release
     app.kubernetes.io/component: value-long-service-name-value-long-service-name-value
 data:
   servicenamePostfix: _value-long-service-name-value-long-service-name-value
   servicenamePostfix_servicename: value-long-service-name-value-long-service-name-value
-  name: chart-long-name-chart-long-name-chart-long-name-chart
+  name: chart-name
   name_nameOverride: value-long-name-override-value-long-name-override-value
-  fullname: release-long-name-re-chart-long-name-cha-value-long-service-nam
-  fullname_fullnameOverride: value-long-full-name-override
-  fullname_fullnameOverride_servicename: value-long-full-name-override-argument-long-servcie-name-argume
+  name_valueOverride: values-override
+  name_valueOverride_nameOverride: value-long-name-override-value-long-name-override-value
+  fullname: release-long-name-re-chart-name-value-long-service-name-value-l
+  fullname_fullnameOverride: value-long-full-name-override-value-long
+  fullname_fullnameOverride_servicename: value-long-full-name-override-value-long-argument-service-name
   fullname_nameOverride: release-long-name-re-value-long-name-ove
-  fullname_nameOverride_servicename: release-long-name-re-value-long-name-ove-argument-long-servcie
-  chart: chart-long-name-chart-long-name-chart-long-name-chart
+  fullname_nameOverride_servicename: release-long-name-re-value-long-name-ove-argument-service-name
+  chart: chart-name

--- a/tests/long_service_name.yaml
+++ b/tests/long_service_name.yaml
@@ -1,1 +1,7 @@
 serviceName: value-long-service-name-value-long-service-name-value
+
+nameOverrideObject:
+  nameOverride: 'value-long-name-override-value-long-name-override-value'
+
+fullnameOverrideObject:
+  fullnameOverride: 'value-long-full-name-override-value-long-full-name-override-value'

--- a/values.md
+++ b/values.md
@@ -13,10 +13,12 @@
 
 ## Definitions
 
-- <a id="definitions/nameOverride"></a>**`nameOverride`** _(string)_: [helm-common] Override the name.
-- <a id="definitions/fullnameOverride"></a>**`fullnameOverride`** _(string)_: [helm-common] Override the fullname.
-- <a id="definitions/releaseTrunc"></a>**`releaseTrunc`** _(integer)_: [helm-common] The release trunk length. Default: `20`.
-- <a id="definitions/prefixTrunc"></a>**`prefixTrunc`** _(integer)_: [helm-common] The prefix trunk length (release and chart name). Default: `40`.
+- <a id="definitions/nameOverride"></a>**`nameOverride`** _(string)_: [helm-common] Override the name (can be in the service or values).
+- <a id="definitions/fullnameOverride"></a>**`fullnameOverride`** _(string)_: [helm-common] Override the fullname (can be in the service or values).
+- <a id="definitions/releaseNameOverride"></a>**`releaseNameOverride`** _(string)_: [helm-common] Override the the release name (can be in the service, values or global).
+- <a id="definitions/releaseTrunc"></a>**`releaseTrunc`** _(integer)_: [helm-common] The release name trunk length (can be in the service, values or global). Default: `20`.
+- <a id="definitions/nameTrunc"></a>**`nameTrunc`** _(integer)_: [helm-common] The chart name trunk length (can be in the service, values or global). Default: `63`.
+- <a id="definitions/prefixTrunc"></a>**`prefixTrunc`** _(integer)_: [helm-common] The prefix trunk length (release and chart name) (can be in the service, values or global). Default: `40`.
 - <a id="definitions/labels"></a>**`labels`** _(object)_: [helm-common] Labels. Can contain additional properties.
   - **Additional properties** _(string)_
 - <a id="definitions/annotations"></a>**`annotations`** _(object)_: [helm-common] Annotations. Can contain additional properties.

--- a/values.schema.json
+++ b/values.schema.json
@@ -7,20 +7,29 @@
   "definitions": {
     "nameOverride": {
       "type": "string",
-      "description": "[helm-common] Override the name"
+      "description": "[helm-common] Override the name (can be in the service or values)"
     },
     "fullnameOverride": {
       "type": "string",
-      "description": "[helm-common] Override the fullname"
+      "description": "[helm-common] Override the fullname (can be in the service or values)"
+    },
+    "releaseNameOverride": {
+      "type": "string",
+      "description": "[helm-common] Override the the release name (can be in the service, values or global)"
     },
     "releaseTrunc": {
       "type": "integer",
-      "description": "[helm-common] The release trunk length",
+      "description": "[helm-common] The release name trunk length (can be in the service, values or global)",
       "default": 20
+    },
+    "nameTrunc": {
+      "type": "integer",
+      "description": "[helm-common] The chart name trunk length (can be in the service, values or global)",
+      "default": 63
     },
     "prefixTrunc": {
       "type": "integer",
-      "description": "[helm-common] The prefix trunk length (release and chart name)",
+      "description": "[helm-common] The prefix trunk length (release and chart name) (can be in the service, values or global)",
       "default": 40
     },
     "labels": {


### PR DESCRIPTION
New service values:
- `releaseTrunc` default to 20
- `releaseNameOverride`

All the values used to build the names can come from `Values` root.

All the values used to build the names can come from `globals` except the `nameOverride` and the `fullNameOverride`.