### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,6 +171,7 @@ repos:
         additional_dependencies:
           - prospector-profile-utils==1.27.0 # pypi
           - ruff==0.16.0 # pypi
+          - pylint[spelling]==4.0.7 # pypi
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.0
     hooks:


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.