### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
         run: c2cciutils-env
 
       - run: poetry install
-      - run: poetry run prospector --output=pylint --die-on-tool-error
+      - run: poetry run prospector --output=pylint --direct-tool-stdout
 
       - name: Setup k3s/k3d
         run: c2cciutils-k8s-install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
       - id: prospector
         args:
           - --profile=utils:pre-commit
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=.prospector.yaml
         additional_dependencies:
@@ -164,7 +164,7 @@ repos:
           )
       - id: prospector
         args:
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=utils:tests
           - --profile=utils:pre-commit


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.